### PR TITLE
Fixes / updates for Flow ingest POC

### DIFF
--- a/webrtc/sendrecv/gst/webrtc-sendrecv.c
+++ b/webrtc/sendrecv/gst/webrtc-sendrecv.c
@@ -380,7 +380,7 @@ start_pipeline (void)
   pipe1 =
       gst_parse_launch ("webrtcbin bundle-policy=max-bundle name=sendrecv "
       STUN_SERVER
-      "videotestsrc is-live=true pattern=ball ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! "
+      "autovideosrc device=/dev/video0 ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! "
       "queue ! " RTP_CAPS_VP8 "96 ! sendrecv. "
       "audiotestsrc is-live=true wave=red-noise ! audioconvert ! audioresample ! queue ! opusenc ! rtpopuspay ! "
       "queue ! " RTP_CAPS_OPUS "97 ! sendrecv. ", &error);

--- a/webrtc/sendrecv/gst/webrtc_sendrecv.py
+++ b/webrtc/sendrecv/gst/webrtc_sendrecv.py
@@ -24,10 +24,14 @@ from gi.repository import GstSdp
 
 PIPELINE_DESC = '''
 webrtcbin name=sendrecv bundle-policy=max-bundle
- autovideosrc device=/dev/video0 ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !
- queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
+ autovideosrc device=/dev/video0            ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
+ videotestsrc is-live=true pattern=snow     ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
+ videotestsrc is-live=true pattern=ball     ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
+ videotestsrc is-live=true pattern=smpte    ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
+ videotestsrc is-live=true pattern=gradient ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
 '''
 
+## TODO: Create 16 low-quality channels
 
 from websockets.version import version as wsv
 

--- a/webrtc/sendrecv/gst/webrtc_sendrecv.py
+++ b/webrtc/sendrecv/gst/webrtc_sendrecv.py
@@ -15,12 +15,17 @@ from gi.repository import GstWebRTC
 gi.require_version('GstSdp', '1.0')
 from gi.repository import GstSdp
 
+# PIPELINE_DESC = '''
+# webrtcbin name=sendrecv bundle-policy=max-bundle stun-server=stun://stun.l.google.com:19302
+# autovideosrc device=/dev/video0 ! videoconvert ! queue !
+# x264enc ! video/x-h264, profile=baseline ! rtph264pay !
+# queue ! application/x-rtp,media=video,encoding-name=H264,payload=96  ! sendrecv.
+# '''
+
 PIPELINE_DESC = '''
-webrtcbin name=sendrecv bundle-policy=max-bundle stun-server=stun://stun.l.google.com:19302
- videotestsrc is-live=true pattern=ball ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !
+webrtcbin name=sendrecv bundle-policy=max-bundle
+ autovideosrc device=/dev/video0 ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !
  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
- audiotestsrc is-live=true wave=red-noise ! audioconvert ! audioresample ! queue ! opusenc ! rtpopuspay !
- queue ! application/x-rtp,media=audio,encoding-name=OPUS,payload=96 ! sendrecv.
 '''
 
 
@@ -136,6 +141,7 @@ class WebRTCClient:
         elif 'ice' in msg:
             ice = msg['ice']
             candidate = ice['candidate']
+            print ('Received candidate: ', candidate)
             sdpmlineindex = ice['sdpMLineIndex']
             self.webrtc.emit('add-ice-candidate', sdpmlineindex, candidate)
 

--- a/webrtc/sendrecv/gst/webrtc_sendrecv.py
+++ b/webrtc/sendrecv/gst/webrtc_sendrecv.py
@@ -23,6 +23,7 @@ webrtcbin name=sendrecv bundle-policy=max-bundle stun-server=stun://stun.l.googl
  queue ! application/x-rtp,media=audio,encoding-name=OPUS,payload=96 ! sendrecv.
 '''
 
+
 from websockets.version import version as wsv
 
 class WebRTCClient:
@@ -54,7 +55,7 @@ class WebRTCClient:
     def on_offer_created(self, promise, _, __):
         promise.wait()
         reply = promise.get_reply()
-        offer = reply['offer']
+        offer = reply.get_value('offer')
         promise = Gst.Promise.new()
         self.webrtc.emit('set-local-description', offer, promise)
         promise.interrupt()

--- a/webrtc/sendrecv/js/index.html
+++ b/webrtc/sendrecv/js/index.html
@@ -16,7 +16,7 @@
       .error { color: red; }
       video { height: 200px }
       table { width: 100%; border: 1px solid grey; text-align: center }
-      .table-cell { border: 1px solid gray; background: gray }
+      table td { border: 1px solid gray; background: gray }
     </style>
     <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
     <script src="webrtc.js"></script>
@@ -27,23 +27,8 @@
 
   <body>
     <table>
-      <thead>
-        <tr>
-          <td>Stream 0 / CAM1</td>
-          <td>Stream 1 / Test 1</td>
-          <td>Stream 2 / Test 2</td>
-          <td>Stream 3 / Test 3</td>
-          <td>Stream 4 / Test 4</td>
-        </tr>
-      </thead>
       <tbody>
-        <tr>
-          <td class="table-cell"><video id="stream0" autoplay playsinline></video></td>
-          <td class="table-cell"><video id="stream1" autoplay playsinline></video></td>
-          <td class="table-cell"><video id="stream2" autoplay playsinline></video></td>
-          <td class="table-cell"><video id="stream3" autoplay playsinline></video></td>
-          <td class="table-cell"><video id="stream4" autoplay playsinline></video></td>
-        </tr>
+        <tr id="streams"></tr>
       </tbody>
     </table>
 

--- a/webrtc/sendrecv/js/index.html
+++ b/webrtc/sendrecv/js/index.html
@@ -14,6 +14,9 @@
     <meta charset="utf-8"/>
     <style>
       .error { color: red; }
+      video { height: 200px }
+      table { width: 100%; border: 1px solid grey; text-align: center }
+      .table-cell { border: 1px solid gray; background: gray }
     </style>
     <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
     <script src="webrtc.js"></script>
@@ -23,10 +26,40 @@
   </head>
 
   <body>
-    <div><video id="stream" autoplay playsinline>Your browser doesn't support video</video></div>
+    <table>
+      <thead>
+        <tr>
+          <td>Stream 0 / CAM1</td>
+          <td>Stream 1 / Test 1</td>
+          <td>Stream 2 / Test 2</td>
+          <td>Stream 3 / Test 3</td>
+          <td>Stream 4 / Test 4</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="table-cell"><video id="stream0" autoplay playsinline></video></td>
+          <td class="table-cell"><video id="stream1" autoplay playsinline></video></td>
+          <td class="table-cell"><video id="stream2" autoplay playsinline></video></td>
+          <td class="table-cell"><video id="stream3" autoplay playsinline></video></td>
+          <td class="table-cell"><video id="stream4" autoplay playsinline></video></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <br>
+
     <div>Status: <span id="status">unknown</span></div>
     <div><textarea id="text" cols=40 rows=4></textarea></div>
     <div>Our id is <b id="peer-id">unknown</b></div>
     <br/>
+
+    NOTE: If you see red error go
+    <script>
+      var url = 'https://' + window.location.hostname + ':8443';
+      document.write('<a target="_blank" href="'+ url +'">here</a>');
+    </script>
+    and accept certificate warning
+
   </body>
 </html>

--- a/webrtc/sendrecv/js/index.html
+++ b/webrtc/sendrecv/js/index.html
@@ -28,9 +28,5 @@
     <div><textarea id="text" cols=40 rows=4></textarea></div>
     <div>Our id is <b id="peer-id">unknown</b></div>
     <br/>
-    <div>
-      <div>getUserMedia constraints being used:</div>
-      <div><textarea id="constraints" cols=40 rows=4></textarea></div>
-    </div>
   </body>
 </html>

--- a/webrtc/sendrecv/js/webrtc.js
+++ b/webrtc/sendrecv/js/webrtc.js
@@ -13,17 +13,19 @@ var ws_port;
 // Set this to use a specific peer id instead of a random one
 var default_peer_id;
 // Override with your own STUN servers if you want
-var rtc_configuration = {iceServers: [{urls: "stun:stun.services.mozilla.com"},
-                                      {urls: "stun:stun.l.google.com:19302"}]};
-// The default constraints that will be attempted. Can be overriden by the user.
-var default_constraints = {video: true, audio: true};
+var rtc_configuration = {
+    iceServers: [
+        { urls: "stun:stun.services.mozilla.com" },
+        { urls: "stun:stun.l.google.com:19302" },
+        // { urls: `stun:${window.location.hostname}:3478` },
+        // { urls: `stun:${window.location.hostname}:3479` },
+    ]
+};
 
 var connect_attempts = 0;
 var peer_connection;
 var send_channel;
 var ws_conn;
-// Promise for local stream after constraints are approved by the user
-var local_stream_promise;
 
 function getOurId() {
     return Math.floor(Math.random() * (9000 - 10) + 10).toString();
@@ -59,14 +61,6 @@ function setError(text) {
 }
 
 function resetVideo() {
-    // Release the webcam and mic
-    if (local_stream_promise)
-        local_stream_promise.then(stream => {
-            if (stream) {
-                stream.getTracks().forEach(function (track) { track.stop(); });
-            }
-        });
-
     // Reset the video element and stop showing the last received frame
     var videoElement = getVideoElement();
     videoElement.pause();
@@ -78,14 +72,13 @@ function resetVideo() {
 function onIncomingSDP(sdp) {
     peer_connection.setRemoteDescription(sdp).then(() => {
         setStatus("Remote SDP set");
-        if (sdp.type != "offer")
+        if (sdp.type !== "offer")
             return;
         setStatus("Got SDP offer");
-        local_stream_promise.then((stream) => {
-            setStatus("Got local stream, creating answer");
-            peer_connection.createAnswer()
-            .then(onLocalDescription).catch(setError);
-        }).catch(setError);
+
+        peer_connection.createAnswer()
+            .then(onLocalDescription)
+            .catch(setError);
     }).catch(setError);
 }
 
@@ -94,8 +87,11 @@ function onLocalDescription(desc) {
     console.log("Got local description: " + JSON.stringify(desc));
     peer_connection.setLocalDescription(desc).then(function() {
         setStatus("Sending SDP " + desc.type);
-        sdp = {'sdp': peer_connection.localDescription}
+        const sdp = {'sdp': peer_connection.localDescription}
         ws_conn.send(JSON.stringify(sdp));
+
+        // setStatus("Signaling server to start pipeline" + desc.type);
+        // ws_conn.send('SESSION_OK');
     });
 }
 
@@ -111,45 +107,48 @@ function onIncomingICE(ice) {
 
 function onServerMessage(event) {
     console.log("Received " + event.data);
-    switch (event.data) {
-        case "HELLO":
-            setStatus("Registered with server, waiting for call");
-            return;
-        default:
-            if (event.data.startsWith("ERROR")) {
-                handleIncomingError(event.data);
-                return;
-            }
-	    if (event.data.startsWith("OFFER_REQUEST")) {
-	      // The peer wants us to set up and then send an offer
-              if (!peer_connection)
-                  createCall(null).then (generateOffer);
-	    }
-            else {
-                // Handle incoming JSON SDP and ICE messages
-                try {
-                    msg = JSON.parse(event.data);
-                } catch (e) {
-                    if (e instanceof SyntaxError) {
-                        handleIncomingError("Error parsing incoming JSON: " + event.data);
-                    } else {
-                        handleIncomingError("Unknown error parsing response: " + event.data);
-                    }
-                    return;
-                }
 
-                // Incoming JSON signals the beginning of a call
-                if (!peer_connection)
-                    createCall(msg);
+    if (event.data === "HELLO") {
+        return setStatus("Registered with server, waiting for call");
+    }
 
-                if (msg.sdp != null) {
-                    onIncomingSDP(msg.sdp);
-                } else if (msg.ice != null) {
-                    onIncomingICE(msg.ice);
-                } else {
-                    handleIncomingError("Unknown incoming JSON: " + msg);
-                }
-	    }
+    if (event.data.startsWith("ERROR")) {
+        return handleIncomingError(event.data);
+    }
+
+    // The peer wants us to set up and then send an offer
+    if (event.data.startsWith("OFFER_REQUEST")) {
+        // We should be ignore this for now
+        alert('OFFER_REQUEST');
+        if (!peer_connection)
+            createCall(null).then (generateOffer);
+        return;
+    }
+
+    let msg;
+
+    // Handle incoming JSON SDP and ICE messages
+    try {
+        msg = JSON.parse(event.data);
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            handleIncomingError("Error parsing incoming JSON: " + event.data);
+        } else {
+            handleIncomingError("Unknown error parsing response: " + event.data);
+        }
+        return;
+    }
+
+    // Incoming JSON signals the beginning of a call
+    if (!peer_connection)
+        createCall(msg);
+
+    if (msg.sdp != null) {
+        onIncomingSDP(msg.sdp);
+    } else if (msg.ice != null) {
+        onIncomingICE(msg.ice);
+    } else {
+        handleIncomingError("Unknown incoming JSON: " + msg);
     }
 }
 
@@ -172,26 +171,6 @@ function onServerError(event) {
     window.setTimeout(websocketServerConnect, 3000);
 }
 
-function getLocalStream() {
-    var constraints;
-    var textarea = document.getElementById('constraints');
-    try {
-        constraints = JSON.parse(textarea.value);
-    } catch (e) {
-        console.error(e);
-        setError('ERROR parsing constraints: ' + e.message + ', using default constraints');
-        constraints = default_constraints;
-    }
-    console.log(JSON.stringify(constraints));
-
-    // Add local stream
-    if (navigator.mediaDevices.getUserMedia) {
-        return navigator.mediaDevices.getUserMedia(constraints);
-    } else {
-        errorUserMediaHandler();
-    }
-}
-
 function websocketServerConnect() {
     connect_attempts++;
     if (connect_attempts > 3) {
@@ -202,10 +181,7 @@ function websocketServerConnect() {
     var span = document.getElementById("status");
     span.classList.remove('error');
     span.textContent = '';
-    // Populate constraints
-    var textarea = document.getElementById('constraints');
-    if (textarea.value == '')
-        textarea.value = JSON.stringify(default_constraints);
+
     // Fetch the peer id to use
     peer_id = default_peer_id || getOurId();
     ws_port = ws_port || '8443';
@@ -235,10 +211,6 @@ function onRemoteTrack(event) {
         console.log('Incoming stream');
         getVideoElement().srcObject = event.streams[0];
     }
-}
-
-function errorUserMediaHandler() {
-    setError("Browser doesn't support getUserMedia!");
 }
 
 const handleDataChannelOpen = (event) =>{
@@ -290,29 +262,19 @@ function createCall(msg) {
     send_channel.onclose = handleDataChannelClose;
     peer_connection.ondatachannel = onDataChannel;
     peer_connection.ontrack = onRemoteTrack;
-    /* Send our video/audio to the other peer */
-    local_stream_promise = getLocalStream().then((stream) => {
-        console.log('Adding local stream');
-        peer_connection.addStream(stream);
-        return stream;
-    }).catch(setError);
 
     if (msg != null && !msg.sdp) {
         console.log("WARNING: First message wasn't an SDP message!?");
     }
 
     peer_connection.onicecandidate = (event) => {
-	// We have a candidate, send it to the remote party with the
-	// same uuid
-	if (event.candidate == null) {
-            console.log("ICE Candidate was null, done");
-            return;
-	}
-	ws_conn.send(JSON.stringify({'ice': event.candidate}));
+        // We have a candidate, send it to the remote party with the same uuid
+        if (!event.candidate) {
+            return console.log("ICE Candidate was null, done");
+        }
+
+        ws_conn.send(JSON.stringify({'ice': event.candidate}));
     };
 
-    if (msg != null)
-        setStatus("Created peer connection for call, waiting for SDP");
-
-    return local_stream_promise;
+    if (msg != null) setStatus("Created peer connection for call, waiting for SDP");
 }

--- a/webrtc/signalling/simple_server.py
+++ b/webrtc/signalling/simple_server.py
@@ -227,12 +227,14 @@ class WebRTCSimpleServer(object):
         return uid
 
     def get_ssl_certs(self):
-        if 'letsencrypt' in self.cert_path:
-            chain_pem = os.path.join(self.cert_path, 'fullchain.pem')
-            key_pem = os.path.join(self.cert_path, 'privkey.pem')
-        else:
-            chain_pem = os.path.join(self.cert_path, 'cert.pem')
-            key_pem = os.path.join(self.cert_path, 'key.pem')
+        # if 'letsencrypt' in self.cert_path:
+        #     chain_pem = os.path.join(self.cert_path, 'fullchain.pem')
+        #     key_pem = os.path.join(self.cert_path, 'privkey.pem')
+        # else:
+        #     chain_pem = os.path.join(self.cert_path, 'cert.pem')
+        #     key_pem = os.path.join(self.cert_path, 'key.pem')
+        chain_pem = '/etc/editshare/ssl/server-cert.pem'
+        key_pem = '/etc/editshare/ssl/server.key'
         return chain_pem, key_pem
 
     def get_ssl_ctx(self):


### PR DESCRIPTION
I forked this repo https://github.com/GStreamer/gst-examples for testing WebRTC stuff and added some updates:

 1.  webrtc/sendrecv/gst/webrtc-sendrecv.c

Updated to use /dev/video0 webcam instead of a test input.

2.  webrtc/sendrecv/gst/webrtc_sendrecv.py 

Likewise updated to use video0 webacm and added more test inputs that should be bundled into multiple tracks within one WebRTC stream.

Also fixed one runtime error with getters
```
- offer = reply['offer']
+ offer = reply.get_value('offer')
```

3. In Static html files 

 webrtc/sendrecv/js/index.html and webrtc/sendrecv/js/webrtc.js

I updated these to remove the need for browser to stream audio/video to the server as we're not going to use that.
Also made it dynamic so that when server streams multiple tracks - multiple video elements would appear in a row to simulate upcoming updates in Flow Control.


4. webrtc/signalling/simple_server.py

I think I had a problem with the certs generated by this script: https://github.com/GStreamer/gst-examples/blob/master/webrtc/signalling/generate_cert.sh
So I updated the signaling server to use certs generated by ourselves.
