### PR TITLE
Correct the condition when calling a busy peer in webrtc examples

### DIFF
--- a/webrtc/signalling/simple_server.py
+++ b/webrtc/signalling/simple_server.py
@@ -167,7 +167,7 @@ class WebRTCSimpleServer(object):
                 if callee_id not in self.peers:
                     await ws.send('ERROR peer {!r} not found'.format(callee_id))
                     continue
-                if peer_status is not None:
+                if self.peers[callee_id][2] is not None:
                     await ws.send('ERROR peer {!r} busy'.format(callee_id))
                     continue
                 await ws.send('SESSION_OK')


### PR DESCRIPTION
Hi, 

Thanks for such great examples for reference and study!

I thought there exists a mistake in webrtc signaling server. When a session request is coming, `ERROR` occurs when the callee is busy. But `peer_status` is the status of the caller, which is of course `None` when calling someone, and I thought `self.peers[callee_id][2]` is correct.